### PR TITLE
fix Config.cmake with CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,10 @@ endif (DOXYGEN_FOUND)
 
 #-------------------------------------------------------------
 # generate and install cmake package and version files
-
+if(CMAKE_CUDA_COMPILER)
+  set(CUDA_SUPPORTED ON)
+endif()
+  
 configure_package_config_file(
   Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/parallelprojConfig.cmake

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -3,6 +3,6 @@ include( "${CMAKE_CURRENT_LIST_DIR}/parallelprojTargets.cmake" )
 
 find_package(OpenMP REQUIRED)
 
-if(@CMAKE_CUDA_COMPILER@)
+if(@CUDA_SUPPORTED@)
   set(parallelproj_built_with_CUDA TRUE)
 endif()

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -3,6 +3,10 @@ include( "${CMAKE_CURRENT_LIST_DIR}/parallelprojTargets.cmake" )
 
 find_package(OpenMP REQUIRED)
 
+if (@OpenMP_FOUND@)
+  set(parallelproj_built_with_OpenMP TRUE)
+endif()
+
 if(@CUDA_SUPPORTED@)
   set(parallelproj_built_with_CUDA TRUE)
 endif()


### PR DESCRIPTION
@paskino noticed that the parallelproj_built_with_CUDA  variable wasn't set when importing in STIR.