### PR TITLE
mention PET up top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # parallelproj
 OpenMP and CUDA libraries and python bindings for 3D forward and back projectors
+for PET reconstruction including time-of-flight (TOF) modeling
 
 ## 0. Dependencies
 


### PR DESCRIPTION
Just learned about this package from Kris and I am excited to see 3D TOF PET here!
Seems like it is worth mentioning "PET" somewhere in the top of the readme?
(Unless this package also works for X-ray CT and SPECT?)

BTW,  do the defaults in class `RegularPolygonPETScanner` correspond to some particular PET scanner model?  If so, it would be nice to say which one to help orient people.
