### PR TITLE
bugfix for Gaussian Filter Operation on torch CPU tensors with SCIPY_…

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,22 @@ Changelog
 2.x
 ---
 
+2.0.1 (Jul 24, 2026)
+^^^^^^^^^^^^^^^^^^^^
+
+Bug fixes
+~~~~~~~~~
+
+- **``GaussianFilterOperator`` now works with PyTorch (and array-api-strict) CPU
+  arrays under modern scipy.** The CPU path previously passed the input array
+  straight to ``scipy.ndimage.gaussian_filter``; with array-API-aware scipy
+  (``SCIPY_ARRAY_API`` / scipy ≥ 1.16) this made scipy compute natively in the
+  input's namespace, where ``gaussian_filter1d`` reverses the kernel with a
+  negative-step slice (``weights[::-1]``) that PyTorch does not support. The
+  operator now filters on a NumPy view (zero-copy on CPU) and converts back, so
+  it is robust regardless of the scipy version or ``SCIPY_ARRAY_API``. This
+  fixes downstream use via e.g. DeepInv.
+
 2.0.0 (Jul 17, 2026)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "hatchling.build"
 [project]
 name = "parallelproj"
 # IMPORTANT: bumping a release requires editing this one line.
-version = "2.0.1.dev0"
+version = "2.0.1"
 description = "Python tools for PET projection and reconstruction workflows."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/parallelproj/operators.py
+++ b/src/parallelproj/operators.py
@@ -19,10 +19,14 @@ import array_api_compat
 
 # GPU arrays (CuPy / PyTorch CUDA) are filtered with ``cupyx.scipy.ndimage``
 # directly (see GaussianFilterOperator); CPU arrays (NumPy, PyTorch CPU,
-# array-api-strict) go through ``scipy.ndimage``, which converts them via
-# ``np.asarray``.  Neither path relies on scipy's array-API delegation, so the
-# ``SCIPY_ARRAY_API`` env var is not needed and the operator is independent of
-# the scipy / parallelproj import order.
+# array-api-strict) are converted to a NumPy view first and then filtered with
+# ``scipy.ndimage``.  Neither path relies on scipy's array-API *delegation*
+# (where scipy would compute natively in the input's namespace): under
+# delegation ``gaussian_filter1d`` reverses the kernel with a negative-step
+# slice ``weights[::-1]`` that e.g. PyTorch does not support.  Converting to
+# NumPy ourselves makes the operator robust regardless of the scipy version or
+# the ``SCIPY_ARRAY_API`` env var (and independent of the scipy / parallelproj
+# import order).
 import scipy.ndimage as ndimage
 from array_api_compat import device, get_namespace
 
@@ -31,7 +35,7 @@ try:
 except Exception:
     cp = None
 
-from parallelproj import Array
+from parallelproj import Array, to_numpy_array
 
 
 class LinearOperator(abc.ABC):
@@ -600,10 +604,17 @@ class GaussianFilterOperator(LinearOperator):
             )
             return xp.asarray(xp.from_dlpack(y_cp))
 
-        # CPU arrays (NumPy, PyTorch CPU, array-api-strict) via scipy.ndimage.
-        # scipy may return a plain numpy array even for non-numpy inputs, so
-        # convert the result back to the input's array namespace/device.
-        result = ndimage.gaussian_filter(x, **self._kwargs)
+        # CPU arrays (NumPy, PyTorch CPU, array-api-strict): filter on a NumPy
+        # view, then convert the result back to the input's namespace/device.
+        # We convert to NumPy *ourselves* instead of passing ``x`` to scipy,
+        # because modern (array-API-aware) scipy would otherwise compute
+        # natively in the input's namespace, where ``gaussian_filter1d``
+        # reverses the kernel with a negative-step slice ``weights[::-1]`` that
+        # e.g. PyTorch does not support.  On CPU the torch / array-api-strict
+        # <-> NumPy conversions are zero-copy (shared buffer); only scipy's
+        # output allocation remains, exactly as in the pure-NumPy path.
+        x_np = np.asarray(to_numpy_array(x))
+        result = ndimage.gaussian_filter(x_np, **self._kwargs)
         return xp.asarray(result, device=dev, dtype=x.dtype)
 
     def _adjoint(self, y: Array) -> Array:

--- a/tests/test_gaussian_filter_torch.py
+++ b/tests/test_gaussian_filter_torch.py
@@ -1,0 +1,83 @@
+"""Regression tests for :class:`GaussianFilterOperator` with PyTorch CPU tensors.
+
+Guards against a scipy array-API *delegation* issue: when scipy computes
+natively on a torch tensor, ``scipy.ndimage.gaussian_filter1d`` reverses the
+Gaussian kernel with a negative-step slice (``weights[::-1]``) that PyTorch does
+not support (https://github.com/pytorch/pytorch/issues/175240).  parallelproj
+must therefore filter on a NumPy view, so this never happens regardless of the
+scipy version or the ``SCIPY_ARRAY_API`` env var.
+
+These tests are torch-CPU specific and are intentionally *not* parametrized over
+``(xp, dev)`` (so they do not import ``config.pytestmark``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+torch_available = importlib.util.find_spec("torch") is not None
+
+pytestmark = pytest.mark.skipif(not torch_available, reason="torch not installed")
+
+
+def test_gaussian_filter_operator_torch_cpu() -> None:
+    """A torch CPU tensor stays a torch CPU tensor and matches the NumPy result."""
+    import numpy as np
+    import torch
+    from scipy.ndimage import gaussian_filter
+
+    from parallelproj.operators import GaussianFilterOperator
+
+    shape = (8, 8, 4)
+    op = GaussianFilterOperator(shape, sigma=1.5)
+
+    x = torch.ones(shape, dtype=torch.float32)
+    y = op(x)
+
+    assert isinstance(y, torch.Tensor)
+    assert y.device.type == "cpu"
+    assert tuple(y.shape) == shape
+    assert bool(torch.isfinite(y).all())
+
+    ref = gaussian_filter(np.ones(shape, dtype=np.float32), sigma=1.5)
+    assert np.allclose(np.asarray(y), ref, atol=1e-6)
+
+
+def test_gaussian_filter_operator_torch_cpu_scipy_array_api() -> None:
+    """Force scipy's array-API delegation via ``SCIPY_ARRAY_API=1``.
+
+    scipy reads ``SCIPY_ARRAY_API`` at import time, so this runs in a fresh
+    interpreter with the env var set (which also keeps the rest of the suite on
+    scipy's default behavior).  Under delegation the pre-fix operator hit the
+    unsupported ``weights[::-1]`` negative-step slice on modern scipy; with the
+    NumPy-view fix it succeeds.
+    """
+    code = textwrap.dedent(
+        """
+        import torch
+        from parallelproj.operators import GaussianFilterOperator
+
+        shape = (8, 8, 4)
+        op = GaussianFilterOperator(shape, sigma=1.5)
+        x = torch.ones(shape, dtype=torch.float32)
+        y = op(x)
+        assert isinstance(y, torch.Tensor), type(y)
+        assert tuple(y.shape) == shape
+        assert bool(torch.isfinite(y).all())
+        print("OK")
+        """
+    )
+    env = dict(os.environ, SCIPY_ARRAY_API="1")
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0, (
+        f"subprocess failed:\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    assert "OK" in proc.stdout


### PR DESCRIPTION
<!--
Thanks for contributing to parallelproj!
See CONTRIBUTING.md for setup, conventions and the full workflow.
Keep PRs focused on a single change.
-->

## Summary

(Fixes https://github.com/deepinv/deepinv/pull/1298)

## Checklist

- [x] Tests added/updated and `pixi run test` passes (parametrized over `(xp, dev)` where relevant)
- [x] Coverage holds (`pixi run test-cov`)
- [x] Code is array-API compatible (works across NumPy / array_api_strict / PyTorch / CuPy)
- [x] Docs build cleanly (`pixi run docs-fast`)
- [x] `docs/changelog.rst` updated for user-facing changes
- [x] This change belongs in the pure-Python front end (C/CUDA kernel changes go in `libparallelproj`)
